### PR TITLE
Fix #2, Using GSettings instead of hard-coded constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ to:
 
 ## License
 
-This project is licensed under the **GPL-3.0 License**. For more details, see
-the [COPYING](COPYING) file included with this project.
+This project is licensed under the GNU General Public License v3.0 or later
+(GPL-3.0+). For full terms and conditions, refer to the [COPYING](COPYING) file
+included with this project.
 
 ## Dependencies
 

--- a/data/at.shafq.checkwriter.gschema.xml
+++ b/data/at.shafq.checkwriter.gschema.xml
@@ -1,5 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="checkwriter">
 	<schema id="at.shafq.checkwriter" path="/at/shafq/checkwriter/">
+
+		<!-- Font Properties -->
+		<key name="check-font" type="s">
+			<default>'Courier'</default>
+			<summary>Font for the check</summary>
+			<description>The font used for rendering the check.</description>
+		</key>
+		<key name="check-font-height" type="i">
+			<default>10</default>
+			<summary>Font height for the check</summary>
+			<description>The font height used for rendering the check.</description>
+		</key>
+
+		<!-- Check Properties -->
+		<key name="check-width-mm" type="d">
+			<default>152.4</default>
+			<summary>Check width in mm</summary>
+			<description>The width of the check in millimeters.</description>
+		</key>
+		<key name="check-height-mm" type="d">
+			<default>70.0</default>
+			<summary>Check height in mm</summary>
+			<description>The height of the check in millimeters.</description>
+		</key>
+		<key name="check-pad-x-mm" type="d">
+			<default>1.0</default>
+			<summary>Horizontal padding in mm</summary>
+			<description>The horizontal padding for the check layout in millimeters.</description>
+		</key>
+		<key name="check-pad-y-mm" type="d">
+			<default>1.0</default>
+			<summary>Vertical padding in mm</summary>
+			<description>The vertical padding for the check layout in millimeters.</description>
+		</key>
+
+		<!-- Date -->
+		<key name="check-date-pos-x-mm" type="d">
+			<default>85.0</default>
+			<summary>Date position from left) in mm</summary>
+			<description>The distance date field on the check from left in millimeters.</description>
+		</key>
+		<key name="check-date-pos-y-mm" type="d">
+			<default>19.0</default>
+			<summary>Date position from top in mm</summary>
+			<description>The distance date field on the check from top in millimeters.</description>
+		</key>
+		<key name="check-date-width-mm" type="d">
+			<default>38.0</default>
+			<summary>Date field width in mm</summary>
+			<description>The width of the date field on the check in millimeters.</description>
+		</key>
+
+		<!-- Name -->
+		<key name="check-name-pos-x-mm" type="d">
+			<default>16.0</default>
+			<summary>Name position from left in mm</summary>
+			<description>The distance of the name field on the check from the left edge in
+				millimeters.</description>
+		</key>
+		<key name="check-name-pos-y-mm" type="d">
+			<default>29.5</default>
+			<summary>Name position from top in mm</summary>
+			<description>The distance of the name field on the check from the top edge in
+				millimeters.</description>
+		</key>
+		<key name="check-name-width-mm" type="d">
+			<default>97.0</default>
+			<summary>Name field width in mm</summary>
+			<description>The width of the name field on the check in millimeters.</description>
+		</key>
+
+		<!-- Amount -->
+		<key name="check-amount-pos-x-mm" type="d">
+			<default>121.0</default>
+			<summary>Amount position from left in mm</summary>
+			<description>The distance of the amount field on the check from the left edge in
+				millimeters.</description>
+		</key>
+		<key name="check-amount-pos-y-mm" type="d">
+			<default>29.0</default>
+			<summary>Amount position from top in mm</summary>
+			<description>The distance of the amount field on the check from the top edge in
+				millimeters.</description>
+		</key>
+		<key name="check-amount-width-mm" type="d">
+			<default>25.0</default>
+			<summary>Amount field width in mm</summary>
+			<description>The width of the amount field on the check in millimeters.</description>
+		</key>
+
+		<!-- Amount in Words -->
+		<key name="check-amount-in-words-pos-x-mm" type="d">
+			<default>6.0</default>
+			<summary>Amount in words position from left in mm</summary>
+			<description>The distance of the amount in words field on the check from the left edge
+				in millimeters.</description>
+		</key>
+		<key name="check-amount-in-words-pos-y-mm" type="d">
+			<default>37.0</default>
+			<summary>Amount in words position from top in mm</summary>
+			<description>The distance of the amount in words field on the check from the top edge in
+				millimeters.</description>
+		</key>
+		<key name="check-amount-in-words-width-mm" type="d">
+			<default>113.0</default>
+			<summary>Amount in words field width in mm</summary>
+			<description>The width of the amount in words field on the check in millimeters.</description>
+		</key>
+
+		<!-- Memo -->
+		<key name="check-memo-pos-x-mm" type="d">
+			<default>10.0</default>
+			<summary>Memo position from left in mm</summary>
+			<description>The distance of the memo field on the check from the left edge in
+				millimeters.</description>
+		</key>
+		<key name="check-memo-pos-y-mm" type="d">
+			<default>56.0</default>
+			<summary>Memo position from top in mm</summary>
+			<description>The distance of the memo field on the check from the top edge in
+				millimeters.</description>
+		</key>
+		<key name="check-memo-width-mm" type="d">
+			<default>59.0</default>
+			<summary>Memo field width in mm</summary>
+			<description>The width of the memo field on the check in millimeters.</description>
+		</key>
 	</schema>
 </schemalist>

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,5 +1,3 @@
-application_id = 'at.shafq.checkwriter'
-
 scalable_dir = 'hicolor' / 'scalable' / 'apps'
 install_data(
   scalable_dir / ('@0@.svg').format(application_id),

--- a/meson.build
+++ b/meson.build
@@ -7,12 +7,16 @@ project('checkwriter', 'c',
 i18n = import('i18n')
 gnome = import('gnome')
 cc = meson.get_compiler('c')
+application_id = 'at.shafq.checkwriter'
 
 config_h = configuration_data()
 config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
-config_h.set_quoted('GETTEXT_PACKAGE', 'checkwriter')
+config_h.set_quoted('PACKAGE_NAME', 'checkwriter')
+config_h.set_quoted('PACKAGE_URI', application_id)
 config_h.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+
 configure_file(output: 'config.h', configuration: config_h)
+
 add_project_arguments(['-I' + meson.project_build_root()], language: 'c')
 
 project_c_args = []

--- a/src/check-properties.h
+++ b/src/check-properties.h
@@ -1,5 +1,4 @@
-/* checkwriter-window.c
- *
+/*
  * Copyright (c) 2024 Ayan Shafqat <ayan@shafq.at>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -22,74 +21,55 @@
 #define CHECKWRITER_CEHCK_PROPERTIES_H_
 
 #include <cairo.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
-// Constants
+/* Constants */
 #define DEFAULT_DPI (96.0)
 #define INCH_PER_MM (25.4)
 #define POINTS_PER_INCH (72.0)
 
-// Check properties
-#define CHECK_WIDTH_MM (152.4)
-#define CHECK_HEIGHT_MM (70.0)
-#define CHECK_PADX_MM (1.0)
-#define CHECK_PADY_MM (1.0)
-#define CHECK_FONT_HEIGHT (10)
-#define CHECK_FONT ("Courier")
-#define CHECK_VIEW_FONT_HEIGHT (9)
+/* Check view properties */
 #define CHECK_VIEW_FONT ("Sans")
+#define CHECK_VIEW_FONT_HEIGHT (9)
 
-// Date
-#define CHECK_DATE_POSX_MM (85.0)
-#define CHECK_DATE_POSY_MM (19.0)
-#define CHECK_DATE_WIDTH_MM (38.0)
+#define STRING_LEN (256)
+#define CHECK_PROPERTIES_MAGIC (0xFE55AACC)
 
-// Name
-#define CHECK_NAME_POSX_MM (16.0)
-#define CHECK_NAME_POSY_MM (29.5)
-#define CHECK_NAME_WIDTH_MM (97.0)
-
-// Amount
-#define CHECK_AMOUNT_POSX_MM (121.0)
-#define CHECK_AMOUNT_POSY_MM (29.0)
-#define CHECK_AMOUNT_WIDTH_MM (25.0)
-
-// Amount in words
-#define CHECK_AMOUNT_IN_WORDS_POSX_MM (6.0)
-#define CHECK_AMOUNT_IN_WORDS_POSY_MM (37.0)
-#define CHECK_AMOUNT_IN_WORDS_WIDTH_MM (113.0)
-
-// Memo
-#define CHECK_MEMO_POSX_MM (10.0)
-#define CHECK_MEMO_POSY_MM (56.0)
-#define CHECK_MEMO_WIDTH_MM (59.0)
-
+/* Check view flags */
 #define CHECK_PREVIEW_ONLY (0x3)
 #define CHECK_TEMPLATE (0x1)
 #define CHECK_WRITE (0x0)
 
-#define STRING_LEN (256)
-
 typedef struct check_field_propperties
 {
-  double x_pos; // X position in mm
-  double y_pos; // Y position in mm
-  double width; // Width in mm
+  double x_pos; /* X position in mm */
+  double y_pos; /* Y position in mm */
+  double width; /* Width in mm */
 } FieldProperties;
 
-// All fields are in millimeters
+/* All fields are in millimeters */
 typedef struct check_properties
 {
-  double width;  // Width in mm
-  double height; // Height in mm
-  double x_pad;  // Horizontal padding in fields
-  double y_pad;  // Vertical padding
   FieldProperties date;
   FieldProperties name;
   FieldProperties amount;
   FieldProperties amount_in_words;
   FieldProperties memo;
+
+  char check_font[STRING_LEN]; /* Fonts for check fields */
+  int check_font_height;       /* Font height in points */
+
+  double width;  /* Width in mm */
+  double height; /* Height in mm */
+  double x_pad;  /* Horizontal padding in fields */
+  double y_pad;  /* Vertical padding */
+
+  uint32_t magic; /* Magic value to signal initialized */
 } CheckProperties;
 
 typedef struct check_data
@@ -109,7 +89,13 @@ typedef struct display_properties
   double y_dpi;
 } DisplayProperties;
 
-void check_properties_init (CheckProperties *p);
+int check_properties_load (CheckProperties *p);
+
+void check_properties_mark_settings_changed (void);
+
+bool check_properties_settings_changed (void);
+
+int check_properties_store (CheckProperties *p);
 
 void check_data_init (CheckData *p);
 
@@ -122,5 +108,7 @@ void render_check (cairo_t *cr,
                    const CheckProperties *cprop,
                    const CheckData *cdata,
                    int flags);
+
+void check_data_set_sample (CheckData *check_data);
 
 #endif /* CHECKWRITER_CEHCK_PROPERTIES_H_ */

--- a/src/checkwriter-preferences.c
+++ b/src/checkwriter-preferences.c
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2024 Ayan Shafqat <ayan@shafq.at>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "checkwriter-preferences.h"
+#include "check-properties.h"
+
+/**
+ * Type definitions
+ */
+struct _CheckwriterPreferences
+{
+  GtkWidget parent_instance;
+
+  CheckProperties check_properties;
+
+  GtkWindow *preferences_window;
+
+  GtkButton *apply_button;
+  GtkButton *cancel_button;
+
+  GtkSpinButton *check_width_spin;
+  GtkSpinButton *check_height_spin;
+  GtkSpinButton *x_pad_spin;
+  GtkSpinButton *y_pad_spin;
+
+  GtkSpinButton *date_x_spin;
+  GtkSpinButton *date_y_spin;
+  GtkSpinButton *date_width_spin;
+
+  GtkSpinButton *pay_to_x_spin;
+  GtkSpinButton *pay_to_y_spin;
+  GtkSpinButton *pay_to_width_spin;
+
+  GtkSpinButton *amount_x_spin;
+  GtkSpinButton *amount_y_spin;
+  GtkSpinButton *amount_width_spin;
+
+  GtkSpinButton *amount_words_x_spin;
+  GtkSpinButton *amount_words_y_spin;
+  GtkSpinButton *amount_words_width_spin;
+
+  GtkSpinButton *memo_x_spin;
+  GtkSpinButton *memo_y_spin;
+  GtkSpinButton *memo_width_spin;
+
+  GtkWidget *check_preview_area;
+};
+
+G_DEFINE_TYPE (CheckwriterPreferences, checkwriter_preferences, GTK_TYPE_WIDGET)
+
+/***
+ * Methods
+ */
+
+static void
+checkwriter_preferences_load_settings (CheckwriterPreferences *self)
+{
+  if (!self)
+    {
+      g_warning ("Self not initialized, not loading settings");
+      return;
+    }
+  check_properties_load (&self->check_properties);
+
+  /* Load current settings */
+  gtk_spin_button_set_value (self->check_width_spin, self->check_properties.width);
+  gtk_spin_button_set_value (self->check_height_spin, self->check_properties.height);
+  gtk_spin_button_set_value (self->x_pad_spin, self->check_properties.x_pad);
+  gtk_spin_button_set_value (self->y_pad_spin, self->check_properties.y_pad);
+
+  gtk_spin_button_set_value (self->date_x_spin, self->check_properties.date.x_pos);
+  gtk_spin_button_set_value (self->date_y_spin, self->check_properties.date.y_pos);
+  gtk_spin_button_set_value (self->date_width_spin, self->check_properties.date.width);
+
+  gtk_spin_button_set_value (self->pay_to_x_spin, self->check_properties.name.x_pos);
+  gtk_spin_button_set_value (self->pay_to_y_spin, self->check_properties.name.y_pos);
+  gtk_spin_button_set_value (self->pay_to_width_spin, self->check_properties.name.width);
+
+  gtk_spin_button_set_value (self->amount_x_spin, self->check_properties.amount.x_pos);
+  gtk_spin_button_set_value (self->amount_y_spin, self->check_properties.amount.y_pos);
+  gtk_spin_button_set_value (self->amount_width_spin, self->check_properties.amount.width);
+
+  gtk_spin_button_set_value (self->amount_words_x_spin, self->check_properties.amount_in_words.x_pos);
+  gtk_spin_button_set_value (self->amount_words_y_spin, self->check_properties.amount_in_words.y_pos);
+  gtk_spin_button_set_value (self->amount_words_width_spin, self->check_properties.amount_in_words.width);
+
+  gtk_spin_button_set_value (self->memo_x_spin, self->check_properties.memo.x_pos);
+  gtk_spin_button_set_value (self->memo_y_spin, self->check_properties.memo.y_pos);
+  gtk_spin_button_set_value (self->memo_width_spin, self->check_properties.memo.width);
+}
+
+/**
+ * Event handlers
+ */
+
+static void
+checkwriter_preferences_on_cancel_button_clicked (GtkButton *button,
+                                                  gpointer user_data)
+{
+  CheckwriterPreferences *self = NULL;
+
+  self = CHECKWRITER_PREFERENCES (user_data);
+
+  if (!self)
+    {
+      g_error ("%s: Failed to retrieve instance. Invalid user_data parameter.", __func__);
+      return;
+    }
+
+  g_debug ("%s: Preferences window closed without saving.", __func__);
+  gtk_window_destroy (GTK_WINDOW (self->preferences_window));
+}
+
+static void
+checkwriter_preferences_on_apply_button_clicked (GtkButton *button,
+                                                 gpointer user_data)
+{
+  CheckwriterPreferences *self = NULL;
+
+  self = CHECKWRITER_PREFERENCES (user_data);
+
+  if (!self)
+    {
+      g_error ("%s: Failed to retrieve instance. Invalid user_data parameter.", __func__);
+      return;
+    }
+
+  /* Apply the settings */
+
+  if (check_properties_store (&self->check_properties) < 0)
+    {
+      g_error ("%s: Error changing settings", __func__);
+      g_abort ();
+    }
+
+  g_debug ("%s: Preference window closed after settings applied", __func__);
+  gtk_window_destroy (GTK_WINDOW (self->preferences_window));
+}
+
+static void
+checkwriter_preferences_on_spin_value_change (GtkSpinButton *spin,
+                                              gpointer user_data)
+{
+  CheckwriterPreferences *self = NULL;
+
+  self = CHECKWRITER_PREFERENCES (user_data);
+
+  if (!self)
+    {
+      g_error ("%s: Failed to retrieve instance. Invalid user_data parameter.", __func__);
+      return;
+    }
+
+  /* Get each ID and populate it with appropirate value */
+  if (spin == self->check_width_spin)
+    {
+      self->check_properties.width = gtk_spin_button_get_value (self->check_width_spin);
+    }
+  else if (spin == self->check_height_spin)
+    {
+      self->check_properties.height = gtk_spin_button_get_value (self->check_height_spin);
+    }
+  else if (spin == self->x_pad_spin)
+    {
+      self->check_properties.x_pad = gtk_spin_button_get_value (self->x_pad_spin);
+    }
+  else if (spin == self->y_pad_spin)
+    {
+      self->check_properties.y_pad = gtk_spin_button_get_value (self->y_pad_spin);
+    }
+  /* Date */
+  else if (spin == self->date_x_spin)
+    {
+      self->check_properties.date.x_pos = gtk_spin_button_get_value (self->date_x_spin);
+    }
+  else if (spin == self->date_y_spin)
+    {
+      self->check_properties.date.y_pos = gtk_spin_button_get_value (self->date_y_spin);
+    }
+  else if (spin == self->date_width_spin)
+    {
+      self->check_properties.date.width = gtk_spin_button_get_value (self->date_width_spin);
+    }
+  /* Name */
+  else if (spin == self->pay_to_x_spin)
+    {
+      self->check_properties.name.x_pos = gtk_spin_button_get_value (self->pay_to_x_spin);
+    }
+  else if (spin == self->pay_to_y_spin)
+    {
+      self->check_properties.name.y_pos = gtk_spin_button_get_value (self->pay_to_y_spin);
+    }
+  else if (spin == self->pay_to_width_spin)
+    {
+      self->check_properties.name.width = gtk_spin_button_get_value (self->pay_to_width_spin);
+    }
+  /* Amount */
+  else if (spin == self->amount_x_spin)
+    {
+      self->check_properties.amount.x_pos = gtk_spin_button_get_value (self->amount_x_spin);
+    }
+  else if (spin == self->amount_y_spin)
+    {
+      self->check_properties.amount.y_pos = gtk_spin_button_get_value (self->amount_y_spin);
+    }
+  else if (spin == self->amount_width_spin)
+    {
+      self->check_properties.amount.width = gtk_spin_button_get_value (self->amount_width_spin);
+    }
+  /* Amount words */
+  else if (spin == self->amount_words_x_spin)
+    {
+      self->check_properties.amount_in_words.x_pos = gtk_spin_button_get_value (self->amount_words_x_spin);
+    }
+  else if (spin == self->amount_words_y_spin)
+    {
+      self->check_properties.amount_in_words.y_pos = gtk_spin_button_get_value (self->amount_words_y_spin);
+    }
+  else if (spin == self->amount_words_width_spin)
+    {
+      self->check_properties.amount_in_words.width = gtk_spin_button_get_value (self->amount_words_width_spin);
+    }
+  /* Memo */
+  else if (spin == self->memo_x_spin)
+    {
+      self->check_properties.memo.x_pos = gtk_spin_button_get_value (self->memo_x_spin);
+    }
+  else if (spin == self->memo_y_spin)
+    {
+      self->check_properties.memo.y_pos = gtk_spin_button_get_value (self->memo_y_spin);
+    }
+  else if (spin == self->memo_width_spin)
+    {
+      self->check_properties.memo.width = gtk_spin_button_get_value (self->memo_width_spin);
+    }
+
+  /* Mark global variable changed */
+  check_properties_mark_settings_changed ();
+
+  /* Update the check preview */
+  if (self->check_preview_area)
+    {
+      gtk_widget_queue_draw (self->check_preview_area);
+    }
+}
+
+/**
+ * Drawing functions
+ */
+
+static void
+checkwriter_preferences_draw_check_preview (GtkDrawingArea *area,
+                                            cairo_t *cr,
+                                            int width,
+                                            int height,
+                                            gpointer user_data)
+{
+  CheckwriterPreferences *self = NULL;
+  cairo_surface_t *surface = NULL;
+
+  DisplayProperties display;
+  CheckData check_data;
+
+  double x_scale, y_scale, x_dpi, y_dpi;
+
+  (void) area;
+
+  self = CHECKWRITER_PREFERENCES (user_data);
+  if (!self)
+    {
+      g_error ("%s: Failed to retrieve instance. Invalid `user_data` parameter.", __func__);
+      return;
+    }
+
+  /* Get the target surface */
+  surface = cairo_get_target (cr);
+  if (!surface)
+    {
+      g_error ("%s: Failed to retrieve cairo instance. Invalid `cr` parameter.", __func__);
+      return;
+    }
+
+  /* Get the device scale (this accounts for any scaling on HiDPI displays) */
+  cairo_surface_get_device_scale (surface, &x_scale, &y_scale);
+
+  x_dpi = DEFAULT_DPI * x_scale;
+  y_dpi = DEFAULT_DPI * y_scale;
+
+  display.width = width;
+  display.height = height;
+  display.x_dpi = x_dpi;
+  display.y_dpi = y_dpi;
+
+  check_data_set_sample (&check_data);
+
+  render_check (cr, &display, &self->check_properties, &check_data, CHECK_PREVIEW_ONLY);
+}
+
+/**
+ * Object Initialization
+ */
+
+static void
+checkwriter_preferences_class_init (CheckwriterPreferencesClass *klass)
+{
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  gtk_widget_class_set_template_from_resource (widget_class, CHECKWRITER_PREFERENCES_RESOURCE_FILE);
+  /* Bind the variables to the template */
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, preferences_window);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, apply_button);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, cancel_button);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, check_width_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, check_height_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, x_pad_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, y_pad_spin);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, date_x_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, date_y_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, date_width_spin);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, pay_to_x_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, pay_to_y_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, pay_to_width_spin);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, amount_x_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, amount_y_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, amount_width_spin);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, amount_words_x_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, amount_words_y_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, amount_words_width_spin);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, memo_x_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, memo_y_spin);
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, memo_width_spin);
+
+  gtk_widget_class_bind_template_child (widget_class, CheckwriterPreferences, check_preview_area);
+}
+
+static void
+checkwriter_preferences_init (CheckwriterPreferences *self)
+{
+  /* Initialize template */
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  /* Connect signals */
+  g_signal_connect (self->cancel_button, "clicked",
+                    G_CALLBACK (checkwriter_preferences_on_cancel_button_clicked), self);
+
+  g_signal_connect (self->apply_button, "clicked",
+                    G_CALLBACK (checkwriter_preferences_on_apply_button_clicked), self);
+
+  g_signal_connect (self->check_width_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->check_height_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->x_pad_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->y_pad_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->date_x_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->date_y_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->date_width_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->pay_to_x_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->pay_to_y_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->pay_to_width_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->amount_x_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->amount_y_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->amount_width_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->amount_words_x_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->amount_words_y_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->amount_words_width_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->memo_x_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->memo_y_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  g_signal_connect (self->memo_width_spin, "value-changed",
+                    G_CALLBACK (checkwriter_preferences_on_spin_value_change), self);
+
+  /* Connect drawing area update function */
+  gtk_drawing_area_set_draw_func (GTK_DRAWING_AREA (self->check_preview_area),
+                                  checkwriter_preferences_draw_check_preview, self, NULL);
+
+  g_debug ("%s: Init finished", __func__);
+}
+
+GtkWindow *
+checkwriter_preferences_window_new (GtkApplication *app)
+{
+  CheckwriterPreferences *prefs = NULL;
+
+  /* Allocate the memory for preference*/
+  prefs = g_object_new (CHECKWRITER_TYPE_PREFERENCES, NULL);
+
+  if (!prefs)
+    {
+      g_error ("Error allocating memory for CheckWriterPreferences");
+      return NULL;
+    }
+
+  /* Need to load settings manually for some reason */
+  checkwriter_preferences_load_settings (prefs);
+
+  return prefs->preferences_window;
+}

--- a/src/checkwriter-preferences.h
+++ b/src/checkwriter-preferences.h
@@ -1,5 +1,4 @@
-/* main.c
- *
+/*
  * Copyright (c) 2024 Ayan Shafqat <ayan@shafq.at>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -18,25 +17,18 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include "config.h"
+#ifndef CHECKWRITER_PREFERENCES_WINDOW_H
+#define CHECKWRITER_PREFERENCES_WINDOW_H
 
-#include <glib/gi18n.h>
+#include <gtk/gtk.h>
 
-#include "checkwriter-application.h"
+G_BEGIN_DECLS
+#define CHECKWRITER_TYPE_PREFERENCES (checkwriter_preferences_get_type ())
+G_DECLARE_FINAL_TYPE (CheckwriterPreferences, checkwriter_preferences, CHECKWRITER, PREFERENCES, GtkWidget)
+G_END_DECLS
 
-int
-main (int argc,
-      char *argv[])
-{
-  g_autoptr (CheckwriterApplication) app = NULL;
-  int ret;
+#define CHECKWRITER_PREFERENCES_RESOURCE_FILE ("/at/shafq/checkwriter/checkwriter-preferences.ui")
 
-  bindtextdomain (PACKAGE_NAME, LOCALEDIR);
-  bind_textdomain_codeset (PACKAGE_NAME, "UTF-8");
-  textdomain (PACKAGE_NAME);
+GtkWindow *checkwriter_preferences_window_new (GtkApplication *app);
 
-  app = checkwriter_application_new (PACKAGE_URI, G_APPLICATION_DEFAULT_FLAGS);
-  ret = g_application_run (G_APPLICATION (app), argc, argv);
-
-  return ret;
-}
+#endif /* CHECKWRITER_PREFERENCES_WINDOW_H */

--- a/src/checkwriter-preferences.ui
+++ b/src/checkwriter-preferences.ui
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkWindow" id="preferences_window">
+    <property name="title">Preferences</property>
+    <property name="default-width">1400</property>
+    <property name="default-height">600</property>
+
+    <child>
+      <object class="GtkBox" id="main_box">
+        <property name="orientation">vertical</property>
+        <property name="spacing">10</property>
+
+        <!-- Top Buttons -->
+        <child>
+          <object class="GtkBox" id="button_box">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">10</property>
+            <property name="halign">end</property>
+            <child>
+              <object class="GtkButton" id="apply_button">
+                <property name="label">Apply</property>
+              </object>
+              <!-- End of Apply Button -->
+            </child>
+            <child>
+              <object class="GtkButton" id="cancel_button">
+                <property name="label">Cancel</property>
+              </object>
+              <!-- End of Cancel Button -->
+            </child>
+          </object>
+          <!-- End of Button Box -->
+        </child>
+
+        <!-- Configuration and Preview Content -->
+        <child>
+          <object class="GtkPaned" id="preferences_paned">
+            <property name="orientation">horizontal</property>
+
+            <!-- Left Pane: Configuration Parameters -->
+            <child>
+              <object class="GtkGrid" id="config_grid">
+                <property name="row-spacing">10</property>
+                <property name="column-spacing">10</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+
+                <!-- Headers -->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label"></property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">0</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Horizontal Spacing</property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">0</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Vertical Spacing</property>
+                    <layout>
+                      <property name="column">2</property>
+                      <property name="row">0</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Width</property>
+                    <layout>
+                      <property name="column">3</property>
+                      <property name="row">0</property>
+                    </layout>
+                  </object>
+                </child>
+
+                <!-- Date Row -->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Date</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">1</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="date_x_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">1</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="date_y_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">2</property>
+                      <property name="row">1</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="date_width_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">3</property>
+                      <property name="row">1</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Date Row-->
+
+
+                <!-- Pay To Row -->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Pay To</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">2</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pay_to_x_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">2</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pay_to_y_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">2</property>
+                      <property name="row">2</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pay_to_width_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">3</property>
+                      <property name="row">2</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Pay To Row -->
+
+                <!-- Amount Row -->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Amount</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">3</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="amount_x_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">3</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="amount_y_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">2</property>
+                      <property name="row">3</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="amount_width_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">3</property>
+                      <property name="row">3</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Amount Row -->
+
+                <!-- Amount In Words Row -->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Amount In Words</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">4</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="amount_words_x_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">4</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="amount_words_y_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">2</property>
+                      <property name="row">4</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="amount_words_width_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">3</property>
+                      <property name="row">4</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Amount In Words Row -->
+
+                <!-- Memo Row -->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Memo</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">5</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="memo_x_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">5</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="memo_y_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">2</property>
+                      <property name="row">5</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="memo_width_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">3</property>
+                      <property name="row">5</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Memo Row -->
+
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label"></property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">6</property>
+                    </layout>
+                  </object>
+                </child>
+
+
+                <!-- Check Width-->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Check Width</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">7</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="check_width_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">7</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Check Width -->
+
+
+                <!-- Check Height-->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Check Height</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">8</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="check_height_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">8</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Check Height -->
+
+                <!-- Horizontal Padding-->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Horizontal Padding</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">9</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="x_pad_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">9</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Horizontal Padding -->
+
+                <!-- Vertical Padding-->
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Vertical Padding</property>
+                    <property name="halign">end</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">10</property>
+                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="y_pad_spin">
+                    <property name="digits">2</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">500</property>
+                        <property name="step-increment">0.1</property>
+                        <property name="value">0.0</property>
+                      </object>
+                    </property>
+                    <layout>
+                      <property name="column">1</property>
+                      <property name="row">10</property>
+                    </layout>
+                  </object>
+                </child>
+                <!-- End Vertical Padding -->
+
+              </object>
+              <!-- End of Config Grid -->
+            </child>
+            <!-- Right Pane: Preview -->
+
+            <child>
+              <object class="GtkFrame" id="check_preview_frame">
+                <property name="label" translatable="yes">Preview</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <child>
+                  <object class="GtkDrawingArea" id="check_preview_area" />
+                  <!-- End of Check Preview Area -->
+                </child>
+              </object>
+              <!-- End of Check Preview Frame -->
+            </child>
+
+          </object>
+          <!-- End of Preferences Paned -->
+        </child>
+
+      </object>
+      <!-- End of Main Box -->
+    </child>
+  </object>
+  <!-- End of Preferences Window -->
+</interface>

--- a/src/checkwriter.gresource.xml
+++ b/src/checkwriter.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/at/shafq/checkwriter">
     <file preprocess="xml-stripblanks">checkwriter-window.ui</file>
+    <file preprocess="xml-stripblanks">checkwriter-preferences.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
   </gresource>
 </gresources>

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ checkwriter_sources = [
   'main.c',
   'checkwriter-application.c',
   'checkwriter-window.c',
+  'checkwriter-preferences.c',
   'check-properties.c',
   'num-to-words.c'
 ]


### PR DESCRIPTION
Modified:   README.md

  Clarify license information (GPL-v3.0+)

Modified:   data/at.shafq.checkwriter.gschema.xml

  GSettings Schema Enhancements

  - Add new configuration keys for font customization (check-font, check-font-height), check dimensions (check-width-mm, check-height-mm), etc.

Modified:   data/icons/meson.build

  Make application id URI part of the main build

Modified:   src/main.c
Modified:   src/meson.build
Modified:   meson.build

  Refactor build script to standardize on common package names

Modified:   src/check-properties.c
Modified:   src/check-properties.h

  Remove hard-codec constants over GSettings for better app
  customizations

  - Add new functions to mark and query property changes, improving configuration and customization of the app

  - Introduce thread-safe mechanisms for tracking property change

new file:   src/checkwriter-preferences.c
new file:   src/checkwriter-preferences.h
new file:   src/checkwriter-preferences.ui

  Add new window for customizing check preference

Modified:   src/checkwriter-window.c

  Integrate with new property change schema